### PR TITLE
Fix face-mask-detection.ipynb error in visualize_images function

### DIFF
--- a/face-mask-detection.ipynb
+++ b/face-mask-detection.ipynb
@@ -483,7 +483,7 @@
     "         if os.path.splitext(image)[1].lower() in valid_image_ext]\n",
     "    for idx, img_path in enumerate(a[:num_images]):\n",
     "        col_id = idx % num_cols\n",
-    "        row_id = idx / num_cols\n",
+    "        row_id = idx // num_cols\n",
     "        img = plt.imread(img_path)\n",
     "        axarr[row_id, col_id].imshow(img) "
    ]


### PR DESCRIPTION
Fix no integer division in `visualize_images` function, which can causes a bad indexing of the matplotlib figure